### PR TITLE
Add validation for column in monitor configs

### DIFF
--- a/monosi/monitors/table.py
+++ b/monosi/monitors/table.py
@@ -90,7 +90,11 @@ class TableMonitor(Monitor):
 
     @classmethod
     def validate(cls, monitor_dict):
-        pass
+        if 'columns' not in monitor_dict or len(monitor_dict['columns']) == 0:
+            return False
+
+        # TODO: Better validation
+        return True
 
     @classmethod
     def _create_metrics(cls, columns, allowed_metrics):
@@ -108,6 +112,9 @@ class TableMonitor(Monitor):
     
     @classmethod
     def from_dict(cls, value: Dict[str, Any]) -> 'Monitor':
+        if not cls.validate(value):
+            raise Exception("The monitor definition is not defined correctly.")
+
         table = value['table']
         timestamp_field = value['timestamp_field']
         description = extract_or_default(value, 'description', None)


### PR DESCRIPTION
- updates validate method to check if columns is included in monitor_dict
- calls validate method when creating table monitor from dictionary and
  raises exception on invalid definition

resolves https://github.com/monosidev/monosi/issues/16