### PR TITLE
Remove job if monitor is deleted

### DIFF
--- a/src/server/models/monitor.py
+++ b/src/server/models/monitor.py
@@ -132,6 +132,10 @@ class Monitor(MonitorDefinition, Base, CrudMixin):
         self.schedule()
         # self.run()
 
+    def delete(self):
+        manager.remove_job(self.id)
+        return super().delete()
+
     # TODO: Implementation - should remove route while pending
     # def update(self):
     #     pass


### PR DESCRIPTION
## Pull request type

- [ x ] Bugfix

## Issue

If a monitor is deleted from the frontend, it is not removed from running in the scheduler

## Description of change & new behavior

It is now removed
