### PR TITLE
Set scheduler to run more immediately after monitor creation instead …

### DIFF
--- a/src/scheduler/base.py
+++ b/src/scheduler/base.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from flask_apscheduler import APScheduler
 import json
 import uuid
@@ -66,6 +67,8 @@ class MsiScheduler(APScheduler):
         arguments = [monitor_job.run, job_id]
         arguments.extend(args)
 
-        self.add_job(func=self.run_job, id=job_id, args=arguments, trigger=trigger, minutes=minutes)
+        start_date = datetime.now() - timedelta(minutes=(minutes-1)) # start one minute after schedule
+
+        self.add_job(func=self.run_job, id=job_id, args=arguments, trigger=trigger, minutes=minutes, start_date=start_date)
 
         return job_id


### PR DESCRIPTION
…of waiting initial interval

## Pull request type

Please check the type of change your PR introduces:

- [ x ] Other 

## Issue

Monitor currently waits the interval that it runs at to collect initial data

## Description of change & new behavior

Collects initial data approximately 1 minute after creation.
