### PR TITLE
Update dockerfile to pull instead of build images by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.dockerignore
+.git
+.idea
+**/build
+**/node_modules
+Dockerfile.*
+docker-compose*.yaml

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ compose-build:
 compose-up:
 	cd ./deployment/docker; docker compose up -d
 
+compose-pull:
+	cd ./deployment/docker; docker compose pull
+
+compose:
+	make compose-pull
+	make compose-up
+
 compose-down:
 	cd ./deployment/docker; docker compose down
 

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -1,3 +1,6 @@
+volumes:
+  data:
+    name: data
 services:
   db:
     image: postgres:14.1-alpine
@@ -9,7 +12,7 @@ services:
     ports:
       - '5432:5432'
     volumes: 
-      - ./db-data/:/var/lib/postgresql/data/
+      - data:/var/lib/postgresql/data/
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/documentation/docs/guides/quick-install.md
+++ b/documentation/docs/guides/quick-install.md
@@ -27,12 +27,12 @@ The following steps will run a local instance of Monosi using the default config
 
 1. Clone the [monosidev/monosi](https://github.com/monosidev/monosi) repository.
 2. Change directory into the root of the project.
-3. Run the `make compose-up` command.
+3. Run the `make compose` command.
 
 ```bash
 git clone https://github.com/monosidev/monosi.git
 cd  monosi
-make compose-up
+make compose
 ```
 
 After the Monosi application has started you can view the Monosi Web interface in your browser: [localhost:3000](http://localhost:3000/)

--- a/documentation/docs/user-guide/getting-started.md
+++ b/documentation/docs/user-guide/getting-started.md
@@ -21,7 +21,7 @@ In order to use Monosi successfully, you will need to complete the following ste
 ```
 git clone https://github.com/monosidev/monosi.git
 cd monosi
-make compose-up
+make compose
 ```
 Navigate to http://localhost:3000 to access the web application once it has started.
 

--- a/documentation/docs/user-guide/introduction.md
+++ b/documentation/docs/user-guide/introduction.md
@@ -24,7 +24,7 @@ Monosi is on a mission to operationalize metadata and use it to improve existing
 ```
 git clone https://github.com/monosidev/monosi.git
 cd monosi
-make compose-up
+make compose
 ```
 
 Visit http://localhost:3000 to view the Monosi application.

--- a/documentation/docs/user-guide/local-deployment.md
+++ b/documentation/docs/user-guide/local-deployment.md
@@ -9,7 +9,7 @@ sidebar_label: Local Deployment (Docker)
 ```
 git clone https://github.com/monosidev/monosi
 cd monosi
-make compose-up
+make compose
 ```
 3. Navigate to http://localhost:3000 via your browser
 4. Start monitoring your data


### PR DESCRIPTION
## Pull request type

Other (please describe):
Updated the makefile command used and in docs to pull the image by default rather than to build it as building takes a long time.

Also added a .dockerignore file for good measure.

Tested locally that the docker configuration works - only call out is potential for the volume to not persist across runs, messing up telemetry, this will need to be checked.