### PR TITLE
add x & y values to plotly tooltip

### DIFF
--- a/src/ui/src/pages/app/metrics/Detail/index.tsx
+++ b/src/ui/src/pages/app/metrics/Detail/index.tsx
@@ -48,7 +48,7 @@ const MetricsDetail: React.FC = () => {
     "x": metrics.map((el: any) => el.time_window_start),
     "y": metrics.map((el: any) => el.value),
     "name": "Values",
-    "hoverinfo": "x",
+    "hoverinfo": "all",
     "mode": "lines+markers",
     "showlegend": false,
     "marker": {


### PR DESCRIPTION
Plotly now shows x and y values when a point is hovered over