### PR TITLE
add monitor status ui filter to monitors table

### DIFF
--- a/src/ui/src/pages/app/monitors/Index/components/MonitorsTable/index.tsx
+++ b/src/ui/src/pages/app/monitors/Index/components/MonitorsTable/index.tsx
@@ -6,7 +6,6 @@ import paginationFactory from "react-bootstrap-table2-paginator";
 
 import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
 
-import { format } from 'date-fns';
 import { formatTimestamp } from 'utils/timestampFormatting';
 
 import './table.css';
@@ -92,7 +91,9 @@ const MonitorsTable: React.FC<{
       <div className="container-fluid py-5">
         <h1 className="display-5 fw-bold">Sorry, no data quality yet!</h1>
         <p className="col-md-8 fs-4">You need to create a data source in order to start monitoring, alerting, and increasing your data quality.</p>
-        <small>If you haven't created a data source yet, <a href="/settings/sources">start there</a></small>
+        <small>If you haven't created a data source yet, <a href="/settings/sources">start there.</a></small>
+        <br/>
+        <small>If you have already created a datasource, monitors may be pending or disabled.</small>
       </div>
     </div>
   );

--- a/src/ui/src/pages/app/monitors/Index/index.tsx
+++ b/src/ui/src/pages/app/monitors/Index/index.tsx
@@ -1,11 +1,21 @@
 import React, { useState, useEffect } from 'react';
 
+import { Button, ButtonGroup } from 'react-bootstrap';
 import MonitorService from 'services/monitors';
 import Page from 'components/Page';
 import MonitorsTable from './components/MonitorsTable';
 
+enum MonitorFilters {
+  ENABLED = "enabled", 
+  PENDING = "pending", 
+  DISABLED = "disabled"
+}
+
+
 const MonitorsIndex: React.FC = () => {
-  const [monitors, setMonitors] = useState([]);
+  const [monitors, setMonitors] = useState<any[]>([]);
+  const [monitorFilter, setMonitorFilter] = useState<MonitorFilters>(MonitorFilters.ENABLED);
+  const [filteredMonitors, setFilteredMonitors] = useState<any[]>(monitors);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const loadMonitors = async () => {
@@ -13,6 +23,7 @@ const MonitorsIndex: React.FC = () => {
     let res = await MonitorService.getAll();
     if (res && res.monitors) {
       setMonitors(res.monitors);
+      filterMonitors(MonitorFilters.ENABLED, res.monitors);
     }
     setIsLoading(false);
   };
@@ -21,6 +32,27 @@ const MonitorsIndex: React.FC = () => {
     loadMonitors();
   }, []);
 
+  const filterMonitors = async (filterType: MonitorFilters, monitors: any[]) => {
+    setMonitorFilter(filterType);
+    let filteredMonitors = [];
+
+    switch (filterType) {
+      case MonitorFilters.PENDING: { 
+        filteredMonitors = monitors.filter(m => m.metrics === 0 && m.timestamp_field !== null)
+        break; 
+     } 
+     case MonitorFilters.DISABLED: {
+        filteredMonitors = monitors.filter(m => m.timestamp_field === null)
+        break; 
+     } 
+     default: { 
+        filteredMonitors = monitors.filter(m => m.timestamp_field !== null && m.metrics !== 0)
+        break; 
+     } 
+    }
+
+    setFilteredMonitors(filteredMonitors);
+  }
 
   return (
     <Page selectedTab="monitors">
@@ -31,8 +63,14 @@ const MonitorsIndex: React.FC = () => {
               <h1 className="h2">Monitors</h1>
             </div>
 
+            <ButtonGroup aria-label="Status Filter" style={{paddingBottom: 24}}>
+              <Button variant={monitorFilter === MonitorFilters.ENABLED ? "primary" : "secondary"} onClick={() => filterMonitors(MonitorFilters.ENABLED, monitors)}>Succeeded</Button>
+              <Button variant={monitorFilter === MonitorFilters.PENDING ? "primary" : "secondary"} onClick={() => filterMonitors(MonitorFilters.PENDING, monitors)}>Pending</Button>
+              <Button variant={monitorFilter === MonitorFilters.DISABLED ? "primary" : "secondary"} onClick={() => filterMonitors(MonitorFilters.DISABLED, monitors)}>Disabled</Button>
+            </ButtonGroup>
+
             <MonitorsTable
-              monitors={monitors}
+              monitors={filteredMonitors}
               isLoading={isLoading}
             />
           </main>


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Feature

## Issue

Couldn't filter monitor table

## Description of change & new behavior

Adds filter to monitor table based on status

## Screenshots
<img width="1435" alt="Screen Shot 2022-03-31 at 12 32 08 AM" src="https://user-images.githubusercontent.com/14094284/160977448-ed1ef82b-3e12-4ec6-aad0-d1c71266000e.png">
<img width="1433" alt="Screen Shot 2022-03-31 at 12 32 17 AM" src="https://user-images.githubusercontent.com/14094284/160977453-c3d1123c-b645-4586-8269-9998ffaf291a.png">
<img width="1432" alt="Screen Shot 2022-03-31 at 12 32 56 AM" src="https://user-images.githubusercontent.com/14094284/160977455-8b660301-c1b3-4be2-819c-ef719f88123c.png">

