### PR TITLE
Set case sensitivity for redshift

### DIFF
--- a/src/ingestion/sources/redshift.py
+++ b/src/ingestion/sources/redshift.py
@@ -1,5 +1,7 @@
 import json
 
+from ingestion.sources.base import SQLAlchemyExtractor
+
 from .postgresql import PostgreSQLSource, PostgreSQLSourceConfiguration
 
 class RedshiftSourceConfiguration(PostgreSQLSourceConfiguration):
@@ -10,14 +12,19 @@ class RedshiftSourceConfiguration(PostgreSQLSourceConfiguration):
     def type(self):
         return "redshift"
 
+class RedshiftExtractor(SQLAlchemyExtractor):
+    def _initialize(self):
+        super()._initialize()
+        self._custom_execute("SET enable_case_sensitive_identifier TO true;")
+
+    # TODO: This is a hacky solution, need to update _execute method in base to support non SELECT statements
+    def _custom_execute(self, sql: str):
+        if not self.connection:
+            raise Exception("Connection has already been closed. Could not execute.")
+        
+        self.connection.execute(sql)
+
 class RedshiftSource(PostgreSQLSource):
-    pass
+    def extractor(self):
+        return RedshiftExtractor(self.configuration)
 
-# NOTE: Classes not currently used
-
-# class RedshiftSourceDialect(PostgreSQLSourceDialect):
-    # TODO: Potential dialect override necessary
-    # pass
-
-# class RedshiftSourceExtractor(PostgreSQLSourceExtractor):
-#     pass


### PR DESCRIPTION
Setting `enable_case_sensitive_identifier` for Redshift queries