### PR TITLE
fix timestamp cast for BigQuery freshness monitor

### DIFF
--- a/src/ingestion/sources/bigquery.py
+++ b/src/ingestion/sources/bigquery.py
@@ -143,7 +143,7 @@ class BigQuerySourceDialect(SQLAlchemySourceDialect):
     
     @classmethod
     def _freshness(cls):
-        return "TIMESTAMP_DIFF(MAX({}), CURRENT_TIMESTAMP, MINUTE)"
+        return "TIMESTAMP_DIFF(MAX(CAST({} AS TIMESTAMP)), CURRENT_TIMESTAMP(), MINUTE)"
 
     @classmethod
     def table_metrics_query(cls, monitor, discovery_data, minutes_ago):


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## Issue

BigQuery TIMEDIFF is failing with date and timestamp when calculating freshness

## Description of change & new behavior

We cast all date time fields in freshness monitor to a TIMESTAMP