### PR TITLE
Fix: only show pagination if certain amount

### DIFF
--- a/src/ui/src/pages/app/executions/Index/components/ExecutionsTable.tsx
+++ b/src/ui/src/pages/app/executions/Index/components/ExecutionsTable.tsx
@@ -79,7 +79,7 @@ const ExecutionsTable: React.FC = () => {
                   <BootstrapTable
                     { ...props.baseProps }
                     bordered={false}
-                    pagination={paginationFactory({ sizePerPage: 10 })}
+                    pagination={executions.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
                   />
                 </div>
             )

--- a/src/ui/src/pages/app/executions/Index/components/JobsTable.tsx
+++ b/src/ui/src/pages/app/executions/Index/components/JobsTable.tsx
@@ -77,7 +77,7 @@ const JobsTable: React.FC = () => {
                 <BootstrapTable
                   { ...props.baseProps }
                   bordered={false}
-                  pagination={paginationFactory({ sizePerPage: 10 })}
+                  pagination={jobs.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
                 />
               </div>
            )

--- a/src/ui/src/pages/app/issues/Index/components/IssuesTable.tsx
+++ b/src/ui/src/pages/app/issues/Index/components/IssuesTable.tsx
@@ -101,7 +101,7 @@ const IssuesTable: React.FC = () => {
                       <BootstrapTable
                         { ...props.baseProps }
                         bordered={false}
-                        pagination={paginationFactory({ sizePerPage: 10 })}
+                        pagination={issues.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
                       />
                     </div>
                   </div>

--- a/src/ui/src/pages/app/metrics/Detail/index.tsx
+++ b/src/ui/src/pages/app/metrics/Detail/index.tsx
@@ -209,7 +209,7 @@ const MetricsDetail: React.FC = () => {
                 data={metrics}
                 columns={columns}
                 bordered={false}
-                pagination={paginationFactory({ sizePerPage: 10 })}
+                pagination={metrics.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
               />
             </div>
           </main>

--- a/src/ui/src/pages/app/monitors/Detail/index.tsx
+++ b/src/ui/src/pages/app/monitors/Detail/index.tsx
@@ -126,7 +126,7 @@ const MonitorsDetail: React.FC = () => {
                       <BootstrapTable
                         { ...props.baseProps }
                         bordered={false}
-                        pagination={paginationFactory({ sizePerPage: 10 })}
+                        pagination={metrics.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
                       />
                     </div>
                   </div>

--- a/src/ui/src/pages/app/monitors/Index/components/MonitorsTable/index.tsx
+++ b/src/ui/src/pages/app/monitors/Index/components/MonitorsTable/index.tsx
@@ -194,7 +194,7 @@ const MonitorsTable: React.FC<{
                 <BootstrapTable
                   { ...props.baseProps }
                   bordered={false}
-                  pagination={paginationFactory({ sizePerPage: 10 })}
+                  pagination={filteredMonitors.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
                 />
               </div>
             </div>

--- a/src/ui/src/pages/settings/Integrations/components/IntegrationsTable.tsx
+++ b/src/ui/src/pages/settings/Integrations/components/IntegrationsTable.tsx
@@ -98,7 +98,7 @@ const IntegrationsTable: React.FC = () => {
     )
   }
 
-  if (integrations.length == 0) { return emptyState() }
+  if (integrations.length === 0) { return emptyState() }
 
   return (
    <div className="table-responsive custom-table custom-table-responsive">
@@ -107,7 +107,7 @@ const IntegrationsTable: React.FC = () => {
        data={integrations}
        columns={columns}
        bordered={false}
-       pagination={paginationFactory({ sizePerPage: 10 })}
+       pagination={integrations.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
      />
    </div>
   );

--- a/src/ui/src/pages/settings/Sources/components/SourcesTable.tsx
+++ b/src/ui/src/pages/settings/Sources/components/SourcesTable.tsx
@@ -146,7 +146,7 @@ const SourcesTable: React.FC = () => {
        data={datasources}
        columns={columns}
        bordered={false}
-       pagination={paginationFactory({ sizePerPage: 10 })}
+       pagination={datasources.length < 10 ? undefined : paginationFactory({ sizePerPage: 10 })}
      />
      {toastVisible && <SourceToasts />}
    </div>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Issue

_Link to the issue (if available)_

pagination #170

_Please describe the current behavior._

Pagination shows even though the amount of items does not require it.

## Description of change & new behavior

_Please describe the changes you made and their new behavior._

Pagination does not show while the amount of items are < 10.
Basically added a condition to check if there are less than 10 items, if so pagination is set to false otherwise the old functionality which supports more pages is added.

## Screenshots

_For frontend updates, please include a screenshot._

## Technical Spec/Implementation Notes

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and run successfully.
- [x] If it's a frontend change, Prettier has been run & all tests pass