### PR TITLE
Load email from server when opening profile form

### DIFF
--- a/src/ui/src/components/forms/ProfileForm/index.tsx
+++ b/src/ui/src/components/forms/ProfileForm/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-
+import UserService from 'services/users';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -9,7 +9,18 @@ import {
 
 
 const ProfileForm: React.FC = () => {
-  const [email, _] = useState('');
+  const [email, setEmail] = useState<string>('');
+
+  useEffect(() => {
+    async function loadEmail() {
+      let res = await UserService.getAll();
+      if (res !== null && res.user && res.user.email) {
+        setEmail(res.user.email);
+      }
+    }
+
+    loadEmail();
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## Issue

https://github.com/monosidev/monosi/issues/183

Current behavior: Email text box in profile form always displays placeholder `example@example.com`

## Description of change & new behavior

New behavior: In profile form it tries to fetch and display the user's email if available, displays placeholder otherwise

## Screenshots

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/3013261/163877714-423d96b7-0a75-4de4-bec0-f9c64b1c0d61.png">


## Technical Spec/Implementation Notes

Please check if your PR fulfills the following requirements:

- [ ] If it's a backend change, tests for the changes have been added and run successfully.
- [ ] If it's a frontend change, Prettier has been run & all tests pass